### PR TITLE
ipfs update

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ NEXT_PUBLIC_FEE = 0.003
 NEXT_PUBLIC_BAKERS_API_URL = https://api.baking-bad.org/v2/bakers
 NEXT_PUBLIC_METADATA_API_MAINNET = https://metadata.templewallet.com/metadata
 NEXT_PUBLIC_METADATA_API_TESTNET = http://localhost:3002/metadata
-NEXT_PUBLIC_MAINNET_TOKENS = ipfs://QmNsD6oMgkAc4w9Hnhnt7vfNV2CmbY1D5TT5AHKy8AnWX9/Quipuswap_List
+NEXT_PUBLIC_MAINNET_TOKENS = ipfs://QmVDiLcRbMwo81KzadNYkkSJuyyVRBd4rgCy6ow4hTsDNw
 NEXT_PUBLIC_TESTNET_TOKENS = ipfs://QmS1vT1Lx76z6YoAZ5wp5LAUCYhVAwZ1qPAahKiEkZDyW4/QS_-_WhiteList_-_Testnet
 DEFAULT_SWAP_URI = tez-KT193D4vozYnhGJQVtw7CoxxqphqUEEwK6Vb
 


### PR DESCRIPTION
https://www.notion.so/madfissolutions/Fix-The-Quipuswap-default-asset-list-should-be-stored-locally-not-on-IPFS-because-the-content-on--005e8f91d2f34ca799973ea10dd74584